### PR TITLE
Valkey docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    networks:
+      - learningplatform
   api:
     build:
       context: ../learn-ops-api
@@ -25,6 +27,8 @@ services:
         condition: service_healthy
     volumes:
       - ../learn-ops-api:/app
+    networks:
+      - learningplatform
   client:
     build:
       context: ../learn-ops-client
@@ -36,5 +40,10 @@ services:
     volumes:
       - ../learn-ops-client:/app
       - /app/node_modules
+    networks:
+      - learningplatform
 volumes:
   learning_platform_data:
+networks:
+  learningplatform:
+    external: true

--- a/valkey/docker-compose.yml
+++ b/valkey/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  valkey:
+    image: valkey/valkey:latest
+    container_name: valkey
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey-data:/data
+    command: ["valkey-server", "--save", "900", "1", "--loglevel", "notice"]
+    restart: unless-stopped
+    networks:
+      - learningplatform
+
+  valkey-monitor:
+    image: valkey/valkey:latest
+    container_name: valkey-monitor
+    depends_on:
+      - valkey
+    entrypoint: ["valkey-cli", "-h", "valkey", "monitor"]
+    restart: unless-stopped
+    networks:
+      - learningplatform
+
+volumes:
+  valkey-data:
+
+networks:
+  learningplatform:
+    external: true


### PR DESCRIPTION
Adding `learningplatform` network references to the monolith (infrastructure, API & client)
Adding docker compose to run the following containers:
 - Valkey
 - Valkey monitor
 
 To test:
 `git fetch`
 `git switch valkey-docker-compose`
 `cd valkey`
 `docker compose up`
 
 Desired result:
 Messenger should start logging
 