### PR TITLE
Metrics

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@
 POSTGRES_DB=learningplatform
 POSTGRES_USER=learnops
 POSTGRES_PASSWORD=learnops123
+DATA_SOURCE_NAME=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/${POSTGRES_DB}?sslmode=disable

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+.roo/
+.roomodes
+context_portal/
+memory-bank/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,18 @@ services:
       - prometheus
     networks:
       - learningplatform
+
+  postgres_exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    container_name: postgres_exporter
+    env_file: ".env"
+    ports:
+     - "9187:9187"
+    depends_on:
+      - database
+    networks:
+      - learningplatform
+      
 volumes:
   learning_platform_data:
   grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,31 @@ services:
       - /app/node_modules
     networks:
       - learningplatform
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command: --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - api # Prometheus will scrape metrics from your Django 'api' service
+    networks:
+      - learningplatform
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3001:3000" # Changed host port from 3000 to 3001
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - learningplatform
 volumes:
   learning_platform_data:
+  grafana_data:
 networks:
   learningplatform:
     external: true

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -7,3 +7,7 @@ scrape_configs:
     metrics_path: '/metrics/metrics' 
     static_configs:
       - targets: ['api:8000']
+
+  - job_name: 'postgresql'
+    static_configs:
+      - targets: ['postgres_exporter:9187']

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'django'
+    metrics_path: '/metrics/metrics' 
+    static_configs:
+      - targets: ['api:8000']


### PR DESCRIPTION
Added prometheus, grafana, and postgres_exporter services to docker compose to set up the metrics environment. Metrics data is collected from both the API and the Postgres database as seen in the scrape_configs in the prometheus.yml file. One new env variable was added, DATA_SOURCE_NAME, used by postgres_exporter. 